### PR TITLE
feat: adding case insensitive comparing to remove words from list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,8 +163,9 @@ class Profanity {
    */
   removeWords(...words: string[]) {
     if (words.length === 0) console.error('Unexpected error: need at last one word to remove');
+    const regex = new RegExp( words.join( "|" ), "i");
     this.wordlist = this.wordlist?.filter((item) => {
-      if (!words.includes(item)) return item;
+      if (! regex.test(item)) return item;
     });
     return this;
   }


### PR DESCRIPTION
When the library checks if a word is a badword or not, it uses case insensitive comparison. 

However, when removing words from the badwords list, the library was using a case sensitive comparison.